### PR TITLE
Define xrange() for Python 3

### DIFF
--- a/dm_control/mujoco/thread_safety_test.py
+++ b/dm_control/mujoco/thread_safety_test.py
@@ -19,8 +19,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from six.moves import xrange  # pylint: disable=redefined-builtin
-
 # Internal dependencies.
 
 from absl.testing import absltest
@@ -28,6 +26,8 @@ from absl.testing import absltest
 from dm_control.mujoco import engine
 from dm_control.mujoco.testing import assets
 from dm_control.mujoco.testing import decorators
+
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 MODEL = assets.get_contents('cartpole.xml')
 NUM_STEPS = 10

--- a/dm_control/mujoco/thread_safety_test.py
+++ b/dm_control/mujoco/thread_safety_test.py
@@ -30,6 +30,11 @@ from dm_control.mujoco.testing import decorators
 MODEL = assets.get_contents('cartpole.xml')
 NUM_STEPS = 10
 
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 
 class ThreadSafetyTest(absltest.TestCase):
 

--- a/dm_control/mujoco/thread_safety_test.py
+++ b/dm_control/mujoco/thread_safety_test.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange  # pylint: disable=redefined-builtin
+
 # Internal dependencies.
 
 from absl.testing import absltest
@@ -29,11 +31,6 @@ from dm_control.mujoco.testing import decorators
 
 MODEL = assets.get_contents('cartpole.xml')
 NUM_STEPS = 10
-
-try:
-  xrange          # Python 2
-except NameError:
-  xrange = range  # Python 3
 
 
 class ThreadSafetyTest(absltest.TestCase):

--- a/dm_control/suite/utils/parse_amc.py
+++ b/dm_control/suite/utils/parse_amc.py
@@ -29,6 +29,11 @@ import numpy as np
 
 from scipy import interpolate
 
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 mjlib = mjbindings.mjlib
 
 MOCAP_DT = 1.0/120.0

--- a/dm_control/suite/utils/parse_amc.py
+++ b/dm_control/suite/utils/parse_amc.py
@@ -21,8 +21,6 @@ from __future__ import print_function
 
 import collections
 
-from six.moves import xrange  # pylint: disable=redefined-builtin
-
 # Internal dependencies.
 
 from dm_control.mujoco.wrapper import mjbindings
@@ -30,6 +28,8 @@ from dm_control.mujoco.wrapper import mjbindings
 import numpy as np
 
 from scipy import interpolate
+
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 mjlib = mjbindings.mjlib
 

--- a/dm_control/suite/utils/parse_amc.py
+++ b/dm_control/suite/utils/parse_amc.py
@@ -21,6 +21,8 @@ from __future__ import print_function
 
 import collections
 
+from six.moves import xrange  # pylint: disable=redefined-builtin
+
 # Internal dependencies.
 
 from dm_control.mujoco.wrapper import mjbindings
@@ -28,11 +30,6 @@ from dm_control.mujoco.wrapper import mjbindings
 import numpy as np
 
 from scipy import interpolate
-
-try:
-  xrange          # Python 2
-except NameError:
-  xrange = range  # Python 3
 
 mjlib = mjbindings.mjlib
 


### PR DESCRIPTION
xrange() was removed from Python 3 in favor of range().