### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For example, on Debian and Ubuntu, this can be done by running
 ## Control Suite quickstart
 
 ```python
+import numpy as np
 from dm_control import suite
 
 # Load one task:


### PR DESCRIPTION
The quickstart snipped assumes numpy as already been imported. This CL adds an import to allow the quickstart snippet to work out-of-the-box as a copy/paste demo.