### PR TITLE
Fix TypeError in mocap_demo.py

### DIFF
--- a/dm_control/suite/demos/mocap_demo.py
+++ b/dm_control/suite/demos/mocap_demo.py
@@ -74,7 +74,7 @@ def main(unused_argv):
     clock_dt = toc - tic
     tic = time.time()
     # Real-time playback not always possible as clock_dt > .03
-    plt.pause(np.max(0.01, .03 - clock_dt))  # Need min display time > 0.0.
+    plt.pause(np.max([0.01, 0.03 - clock_dt])) # Need min display time > 0.0.
     plt.draw()
   plt.waitforbuttonpress()
 


### PR DESCRIPTION
mocap_demo fails with a TypeError:

        "TypeError: 'float' object cannot be interpreted as an index"

because np.max() operates over arrays, not the argument list.

This CL encloses the arguments to np.max() in an array, fixing the
error.