### PR TITLE
Enabling options such as flat_observation for all envs

### DIFF
--- a/dm_control/suite/acrobot.py
+++ b/dm_control/suite/acrobot.py
@@ -42,19 +42,19 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking')
-def swingup(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def swingup(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns Acrobot balance task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Balance(sparse=False, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def swingup_sparse(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def swingup_sparse(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns Acrobot sparse balance."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Balance(sparse=True, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/ball_in_cup.py
+++ b/dm_control/suite/ball_in_cup.py
@@ -42,12 +42,12 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking', 'easy')
-def catch(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def catch(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Ball-in-Cup task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = BallInCup(random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/cartpole.py
+++ b/dm_control/suite/cartpole.py
@@ -45,19 +45,19 @@ def get_model_and_assets(num_poles=1):
 
 
 @SUITE.add('benchmarking')
-def balance(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def balance(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Cartpole Balance task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Balance(swing_up=False, sparse=False, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def balance_sparse(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def balance_sparse(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the sparse reward variant of the Cartpole Balance task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Balance(swing_up=False, sparse=True, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('benchmarking')
@@ -69,27 +69,27 @@ def swingup(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
 
 
 @SUITE.add('benchmarking')
-def swingup_sparse(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def swingup_sparse(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the sparse reward variant of teh Cartpole Swing-Up task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Balance(swing_up=True, sparse=True, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add()
-def two_poles(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def two_poles(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Cartpole Balance task."""
   physics = Physics.from_xml_string(*get_model_and_assets(num_poles=2))
   task = Balance(swing_up=True, sparse=False, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add()
-def three_poles(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def three_poles(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Cartpole Balance task."""
   physics = Physics.from_xml_string(*get_model_and_assets(num_poles=3))
   task = Balance(swing_up=True, sparse=False, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 def _make_model(n_poles):

--- a/dm_control/suite/cheetah.py
+++ b/dm_control/suite/cheetah.py
@@ -46,11 +46,11 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking')
-def run(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def run(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the run task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Cheetah(random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/finger.py
+++ b/dm_control/suite/finger.py
@@ -55,30 +55,30 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking')
-def spin(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def spin(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Spin task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Spin(random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def turn_easy(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def turn_easy(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the easy Turn task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Turn(target_radius=_EASY_TARGET_SIZE, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def turn_hard(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def turn_hard(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the hard Turn task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Turn(target_radius=_HARD_TARGET_SIZE, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/fish.py
+++ b/dm_control/suite/fish.py
@@ -51,21 +51,21 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking')
-def upright(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def upright(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Fish Upright task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Upright(random=random)
   return control.Environment(
-      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit)
+      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def swim(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def swim(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Fish Swim task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Swim(random=random)
   return control.Environment(
-      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit)
+      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/hopper.py
+++ b/dm_control/suite/hopper.py
@@ -54,21 +54,21 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking')
-def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns a Hopper that strives to stand upright, balancing its pose."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Hopper(hopping=False, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def hop(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def hop(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns a Hopper that strives to hop forward."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Hopper(hopping=True, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/humanoid.py
+++ b/dm_control/suite/humanoid.py
@@ -53,39 +53,39 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking')
-def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Stand task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Humanoid(move_speed=0, pure_state=False, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def walk(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def walk(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Walk task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Humanoid(move_speed=_WALK_SPEED, pure_state=False, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def run(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def run(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Run task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Humanoid(move_speed=_RUN_SPEED, pure_state=False, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add()
-def run_pure_state(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def run_pure_state(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Run task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Humanoid(move_speed=_RUN_SPEED, pure_state=True, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/humanoid_CMU.py
+++ b/dm_control/suite/humanoid_CMU.py
@@ -52,21 +52,21 @@ def get_model_and_assets():
 
 
 @SUITE.add()
-def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Stand task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = HumanoidCMU(move_speed=0, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add()
-def run(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def run(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Run task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = HumanoidCMU(move_speed=_RUN_SPEED, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/lqr.py
+++ b/dm_control/suite/lqr.py
@@ -60,26 +60,26 @@ def get_model_and_assets(n_bodies, n_actuators, random):
 
 
 @SUITE.add()
-def lqr_2_1(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def lqr_2_1(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns an LQR environment with 2 bodies of which the first is actuated."""
   return _make_lqr(n_bodies=2,
                    n_actuators=1,
                    control_cost_coef=_CONTROL_COST_COEF,
                    time_limit=time_limit,
-                   random=random)
+                   random=random, **kwargs)
 
 
 @SUITE.add()
-def lqr_6_2(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def lqr_6_2(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns an LQR environment with 6 bodies of which first 2 are actuated."""
   return _make_lqr(n_bodies=6,
                    n_actuators=2,
                    control_cost_coef=_CONTROL_COST_COEF,
                    time_limit=time_limit,
-                   random=random)
+                   random=random, **kwargs)
 
 
-def _make_lqr(n_bodies, n_actuators, control_cost_coef, time_limit, random):
+def _make_lqr(n_bodies, n_actuators, control_cost_coef, time_limit, random, **kwargs):
   """Returns a LQR environment.
 
   Args:
@@ -104,7 +104,7 @@ def _make_lqr(n_bodies, n_actuators, control_cost_coef, time_limit, random):
                                               random=random)
   physics = Physics.from_xml_string(model_string, assets=assets)
   task = LQRLevel(control_cost_coef, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 def _make_body(body_id, stiffness_range, damping_range, random):

--- a/dm_control/suite/manipulator.py
+++ b/dm_control/suite/manipulator.py
@@ -73,47 +73,47 @@ def make_model(use_peg, insert):
 
 
 @SUITE.add('benchmarking', 'hard')
-def bring_ball(observe_target=True, time_limit=_TIME_LIMIT, random=None):
+def bring_ball(observe_target=True, time_limit=_TIME_LIMIT, random=None, **kwargs):
   """Returns manipulator bring task with the ball prop."""
   use_peg = False
   insert = False
   physics = Physics.from_xml_string(*make_model(use_peg, insert))
   task = Bring(use_peg, insert, observe_target, random=random)
   return control.Environment(
-      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit)
+      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('hard')
-def bring_peg(observe_target=True, time_limit=_TIME_LIMIT, random=None):
+def bring_peg(observe_target=True, time_limit=_TIME_LIMIT, random=None, **kwargs):
   """Returns manipulator bring task with the peg prop."""
   use_peg = True
   insert = False
   physics = Physics.from_xml_string(*make_model(use_peg, insert))
   task = Bring(use_peg, insert, observe_target, random=random)
   return control.Environment(
-      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit)
+      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('hard')
-def insert_ball(observe_target=True, time_limit=_TIME_LIMIT, random=None):
+def insert_ball(observe_target=True, time_limit=_TIME_LIMIT, random=None, **kwargs):
   """Returns manipulator insert task with the ball prop."""
   use_peg = False
   insert = True
   physics = Physics.from_xml_string(*make_model(use_peg, insert))
   task = Bring(use_peg, insert, observe_target, random=random)
   return control.Environment(
-      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit)
+      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('hard')
-def insert_peg(observe_target=True, time_limit=_TIME_LIMIT, random=None):
+def insert_peg(observe_target=True, time_limit=_TIME_LIMIT, random=None, **kwargs):
   """Returns manipulator insert task with the peg prop."""
   use_peg = True
   insert = True
   physics = Physics.from_xml_string(*make_model(use_peg, insert))
   task = Bring(use_peg, insert, observe_target, random=random)
   return control.Environment(
-      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit)
+      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/pendulum.py
+++ b/dm_control/suite/pendulum.py
@@ -45,11 +45,11 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking')
-def swingup(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def swingup(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns pendulum swingup task ."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = SwingUp(random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/point_mass.py
+++ b/dm_control/suite/point_mass.py
@@ -43,19 +43,19 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking', 'easy')
-def easy(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def easy(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the easy point_mass task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = PointMass(randomize_gains=False, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add()
-def hard(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def hard(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the hard point_mass task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = PointMass(randomize_gains=True, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/reacher.py
+++ b/dm_control/suite/reacher.py
@@ -45,19 +45,19 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking', 'easy')
-def easy(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def easy(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns reacher with sparse reward with 5e-2 tol and randomized target."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Reacher(target_size=_BIG_TARGET, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def hard(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def hard(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns reacher with sparse reward with 1e-2 tol and randomized target."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = Reacher(target_size=_SMALL_TARGET, random=random)
-  return control.Environment(physics, task, time_limit=time_limit)
+  return control.Environment(physics, task, time_limit=time_limit, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/stacker.py
+++ b/dm_control/suite/stacker.py
@@ -60,23 +60,23 @@ def make_model(n_boxes):
 
 
 @SUITE.add('hard')
-def stack_2(observable=True, time_limit=_TIME_LIMIT, random=None):
+def stack_2(observable=True, time_limit=_TIME_LIMIT, random=None, **kwargs):
   """Returns stacker task with 2 boxes."""
   n_boxes = 2
   physics = Physics.from_xml_string(*make_model(n_boxes=n_boxes))
   task = Stack(n_boxes, observable, random=random)
   return control.Environment(
-      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit)
+      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit, **kwargs)
 
 
 @SUITE.add('hard')
-def stack_4(observable=True, time_limit=_TIME_LIMIT, random=None):
+def stack_4(observable=True, time_limit=_TIME_LIMIT, random=None, **kwargs):
   """Returns stacker task with 4 boxes."""
   n_boxes = 4
   physics = Physics.from_xml_string(*make_model(n_boxes=n_boxes))
   task = Stack(n_boxes, observable, random=random)
   return control.Environment(
-      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit)
+      physics, task, control_timestep=_CONTROL_TIMESTEP, time_limit=time_limit, **kwargs)
 
 
 class Physics(mujoco.Physics):

--- a/dm_control/suite/swimmer.py
+++ b/dm_control/suite/swimmer.py
@@ -54,15 +54,15 @@ def get_model_and_assets(n_joints):
 
 
 @SUITE.add('benchmarking')
-def swimmer6(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def swimmer6(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns a 6-link swimmer."""
-  return _make_swimmer(6, time_limit, random=random)
+  return _make_swimmer(6, time_limit, random=random, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def swimmer15(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def swimmer15(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns a 15-link swimmer."""
-  return _make_swimmer(15, time_limit, random=random)
+  return _make_swimmer(15, time_limit, random=random, **kwargs)
 
 
 def swimmer(n_links=3, time_limit=_DEFAULT_TIME_LIMIT,
@@ -71,13 +71,13 @@ def swimmer(n_links=3, time_limit=_DEFAULT_TIME_LIMIT,
   return _make_swimmer(n_links, time_limit, random=random)
 
 
-def _make_swimmer(n_joints, time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def _make_swimmer(n_joints, time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns a swimmer control environment."""
   model_string, assets = get_model_and_assets(n_joints)
   physics = Physics.from_xml_string(model_string, assets=assets)
   task = Swimmer(random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 def _make_model(n_bodies):

--- a/dm_control/suite/walker.py
+++ b/dm_control/suite/walker.py
@@ -52,30 +52,30 @@ def get_model_and_assets():
 
 
 @SUITE.add('benchmarking')
-def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Stand task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = PlanarWalker(move_speed=0, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def walk(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def walk(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Walk task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = PlanarWalker(move_speed=_WALK_SPEED, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 @SUITE.add('benchmarking')
-def run(time_limit=_DEFAULT_TIME_LIMIT, random=None):
+def run(time_limit=_DEFAULT_TIME_LIMIT, random=None, **kwargs):
   """Returns the Run task."""
   physics = Physics.from_xml_string(*get_model_and_assets())
   task = PlanarWalker(move_speed=_RUN_SPEED, random=random)
   return control.Environment(
-      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP)
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP, **kwargs)
 
 
 class Physics(mujoco.Physics):


### PR DESCRIPTION
Cartpole was the only environment that had the option to pass in **kwargs when loading the environment. This pull request adds that option to all the other environments so that optional arguments such as flat_observation may be used.