### PR TITLE
bugfix - viewer does not work correctly when Physics.reload_from_* functions are called

### DIFF
--- a/dm_control/viewer/application.py
+++ b/dm_control/viewer/application.py
@@ -37,6 +37,7 @@ _SPEED_UP_TIME = user_input.KEY_EQUAL
 _SLOW_DOWN_TIME = user_input.KEY_MINUS
 _HELP = user_input.KEY_F1
 _STATUS = user_input.KEY_F2
+_RELOAD = user_input.KEY_F3
 
 _MAX_FRONTBUFFER_SIZE = 2048
 _MISSING_STATUS_ENTRY = '--'
@@ -218,6 +219,7 @@ class Application(object):
     self._input_map.bind(self._time_multiplier.decrease, _SLOW_DOWN_TIME)
     self._input_map.bind(self._advance_simulation, _ADVANCE_SIMULATION)
     self._input_map.bind(self._restart_runtime, _RESTART)
+    self._input_map.bind(self._on_reload, _RELOAD)
     self._input_map.bind(help_view_toggle, _HELP)
     self._input_map.bind(status_view_toggle, _STATUS)
 

--- a/dm_control/viewer/runtime.py
+++ b/dm_control/viewer/runtime.py
@@ -212,12 +212,15 @@ class Runtime(object):
       True if the operation was successful, False otherwise.
     """
     old_physics = self._env.physics
+    old_data = old_physics.data
 
     with self._error_logger:
       self._time_step = self._env.reset()
 
     new_physics = self._env.physics
-    if new_physics is not old_physics:
+    new_data = new_physics.data
+
+    if new_physics is not old_physics or old_data is not new_data:
       for listener in self.on_physics_changed:
         listener()
     return not self._error_logger.errors_found


### PR DESCRIPTION
When Mujoco data is reloaded by Physics.reload_from_* functions, the viewer is not rendered correctly. It can be resolved by detecting a change in data pointer.  