### PR TITLE
add soccer disable contacts option

### DIFF
--- a/dm_control/locomotion/soccer/__init__.py
+++ b/dm_control/locomotion/soccer/__init__.py
@@ -60,7 +60,7 @@ def _make_players(team_size):
   return home_players + away_players
 
 
-def load(team_size, time_limit=45., random_state=None):
+def load(team_size, time_limit=45., random_state=None, disable_walker_contacts=False):
   """Construct `team_size`-vs-`team_size` soccer environment.
 
   Args:
@@ -68,6 +68,7 @@ def load(team_size, time_limit=45., random_state=None):
       11.
     time_limit: Float, the maximum duration of each episode in seconds.
     random_state: (optional) an int seed or `np.random.RandomState` instance.
+    disable_walker_contacts: if `True`, disable physical contacts between players.
 
   Returns:
     A `composer.Environment` instance.
@@ -84,6 +85,7 @@ def load(team_size, time_limit=45., random_state=None):
           players=_make_players(team_size),
           arena=RandomizedPitch(
               min_size=(32, 24), max_size=(48, 36), keep_aspect_ratio=True),
+          disable_walker_contacts=disable_walker_contacts,
       ),
       time_limit=time_limit,
       random_state=random_state)


### PR DESCRIPTION
From the paper of ["Emergent Coordination through Competition"](https://openreview.net/pdf?id=BkG8sjR5Km). In the section 4.1, it said `We disable contacts between the players, but enable contacts between the players, the pitch and the ball. This makes it impossible for players to foul and avoids the need for a complicated contact rules, and led to more dynamic matches.`. In the file of [https://github.com/deepmind/dm_control/blob/master/dm_control/locomotion/soccer/task.py#L50](https://github.com/deepmind/dm_control/blob/master/dm_control/locomotion/soccer/task.py#L50), I found this option. However, in the environment load function: [https://github.com/deepmind/dm_control/blob/master/dm_control/locomotion/soccer/__init__.py#L83](https://github.com/deepmind/dm_control/blob/master/dm_control/locomotion/soccer/__init__.py#L83), it doesn't include this option and it will cause inconvenient. So, I add `disable_walker_contacts ` to the environment load function to make sure people can set contacts between agents according to their requirements.