### PR TITLE
Default to "file" if no "name" attribute specified for "mesh", "hfield", and "texture" assets

### DIFF
--- a/dm_control/mjcf/element.py
+++ b/dm_control/mjcf/element.py
@@ -109,6 +109,10 @@ class _ElementImpl(base.Element):
   def __init__(self, spec, parent, attributes=None):
     attributes = attributes or {}
 
+    if spec.name in ["mesh", "hfield", "texture"] and not ("name" in attributes) and ("file" in attributes):
+        name, ext = os.path.splitext(attributes["file"])
+        attributes["name"] = name
+
     self._spec = spec
     self._parent = parent
     self._attributes = collections.OrderedDict()

--- a/dm_control/mjcf/element.py
+++ b/dm_control/mjcf/element.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import collections
 import copy
 import sys
+import os
 
 from dm_control.mjcf import attribute as attribute_types
 from dm_control.mjcf import base


### PR DESCRIPTION
MuJoCo uses the filename for certain assets (with some caveats, see below) if a name is not specified. This saves the user from having redundant elements like:

`<mesh name="really_long_name" file="really_long_name.stl" />`

From the MuJoCo 2.0 docs:

For asset/texture:
```
name : string, optional
As with all other assets, a texture must have a name in order to be referenced. However if the texture is loaded from a single file with the file attribute, the explicit name can be omitted and the file name (without the path and extension) becomes the texture name. If the name after parsing is empty and the texture type is not "skybox", the compiler will generate an error.
```
For asset/mesh:
```
name : string, optional
Name of the mesh, used for referencing. If omitted, the mesh name equals the file name without the path and extension.
```
and asset/hfield:
```
name : string, optional
Name of the height field, used for referencing. If the name is omitted and a file name is specified, the height field name equals the file name without the path and extension.
```

This was a quick hack, so I'm sure you'll want to change this to better suite your codebase, but it appears to be functionally correct. I don't handle the edge case for texture since an error will inevitably be thrown later.