### PR TITLE
Make installation of enum34 and futures dependent on Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,10 +171,10 @@ setup(
     keywords='machine learning control physics MuJoCo AI',
     install_requires=[
         'absl-py>=0.7.0',
-        'enum34',
+        'enum34; python_version < "3.4"',
         'dm_env',
         'future',
-        'futures',
+        'futures; python_version == "2.7"',
         'glfw',
         'lxml',
         'numpy',


### PR DESCRIPTION
These packages should not be installed on newer versions of Python, see https://pypi.org/project/enum34/ and https://pypi.org/project/futures/