### PR TITLE
implement egl device selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ available in order render through `dm_control`.
 
 By default, `dm_control` will attempt to use GLFW first, then EGL, then OSMesa.
 You can also specify a particular backend to use by setting the `MUJOCO_GL=`
-environment variable to `"glfw"`, `"egl"`, or `"osmesa"`, respectively.
+environment variable to `"glfw"`, `"egl"`, or `"osmesa"`, respectively. When 
+rendering with EGL, you can specify a GPU used for rendering by setting the
+environment variable `EGL_DEVICE_ID=` to the target GPU ID.
 
 ## Additional instructions for Homebrew users on macOS
 

--- a/dm_control/_render/pyopengl/egl_renderer.py
+++ b/dm_control/_render/pyopengl/egl_renderer.py
@@ -46,7 +46,18 @@ from OpenGL import error
 
 def create_initialized_headless_egl_display():
   """Creates an initialized EGL display directly on a device."""
-  devices = EGL.eglQueryDevicesEXT()
+  all_devices = EGL.eglQueryDevicesEXT()
+  selected_device = os.environ.get("EGL_DEVICE_ID", None)
+  if selected_device is None:
+    candidates = all_devices
+  else:
+    device_idx = int(selected_device)
+    if not 0 <= device_idx < len(all_devices):
+      raise RuntimeError(
+          f"EGL_DEVICE_ID must be an integer between 0 and "
+          f"{len(all_devices) - 1} (inclusive), got {device_idx}.")
+    candidates = all_devices[device_idx: device_idx + 1]
+  for device in candidates:
   if os.environ.get("EGL_DEVICE_ID", None) is not None:
     devices = [devices[int(os.environ["EGL_DEVICE_ID"])]]
   for device in devices:

--- a/dm_control/_render/pyopengl/egl_renderer.py
+++ b/dm_control/_render/pyopengl/egl_renderer.py
@@ -46,7 +46,10 @@ from OpenGL import error
 
 def create_initialized_headless_egl_display():
   """Creates an initialized EGL display directly on a device."""
-  for device in EGL.eglQueryDevicesEXT():
+  devices = EGL.eglQueryDevicesEXT()
+  if os.environ.get("EGL_DEVICE_ID", None) is not None:
+    devices = [devices[int(os.environ["EGL_DEVICE_ID"])]]
+  for device in devices:
     display = EGL.eglGetPlatformDisplayEXT(
         EGL.EGL_PLATFORM_DEVICE_EXT, device, None)
     if display != EGL.EGL_NO_DISPLAY and EGL.eglGetError() == EGL.EGL_SUCCESS:


### PR DESCRIPTION
Implement the EGL render device selection in issue #118 
Select render GPU is a critical feature for running batch of experiments on multi-gpu servers.

Users will be able to select a gpu used for rendering by setting environment variable EGL_DEVICE_ID=x