### PR TITLE
Fixes docstring in autowrap.py to include mjui.h

### DIFF
--- a/dm_control/autowrap/autowrap.py
+++ b/dm_control/autowrap/autowrap.py
@@ -15,7 +15,16 @@
 
 r"""Automatically generates ctypes Python bindings for MuJoCo.
 
-Parses mjdata.h, mjmodel.h, mjrender.h, mjvisualize.h, mjxmacro.h, mjui.h and mujoco.h;
+Parses the following MuJoCo header files:
+
+  mjdata.h
+  mjmodel.h
+  mjrender.h
+  mjui.h
+  mjvisualize.h
+  mjxmacro.h
+  mujoco.h;
+
 generates the following Python source files:
 
   constants.py:  constants

--- a/dm_control/autowrap/autowrap.py
+++ b/dm_control/autowrap/autowrap.py
@@ -15,7 +15,7 @@
 
 r"""Automatically generates ctypes Python bindings for MuJoCo.
 
-Parses mjdata.h, mjmodel.h, mjrender.h, mjvisualize.h, mjxmacro.h and mujoco.h;
+Parses mjdata.h, mjmodel.h, mjrender.h, mjvisualize.h, mjxmacro.h, mjui.h and mujoco.h;
 generates the following Python source files:
 
   constants.py:  constants


### PR DESCRIPTION
Added mjui.h to the docstring for autowrap so those that need to run autowrap directly will not forget to include it in the arguments