### PR TITLE
Fixed installation dm_control on M1

### DIFF
--- a/dm_control/mujoco/wrapper/core.py
+++ b/dm_control/mujoco/wrapper/core.py
@@ -61,7 +61,7 @@ class Error(Exception):
   pass
 
 
-if constants.mjVERSION_HEADER != mjlib.mj_version():
+if constants.mjVERSION_HEADER >= mjlib.mj_version():
   raise Error("MuJoCo library version ({0}) does not match header version "
               "({1})".format(constants.mjVERSION_HEADER, mjlib.mj_version()))
 


### PR DESCRIPTION
Hello,

   after successfully installing the dm_control package I get an error about the Mujoco version, I must use lib from 2.1.1 because only this version is compiled for M1 and is not allowed.

```bash
(base) ➜ martin@MacBook-Pro-uzivatela-Martin  ~  python3                                               
Python 3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 19:24:02) 
[Clang 11.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from dm_control import suite
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/martin/miniforge3/lib/python3.9/site-packages/dm_control/suite/__init__.py", line 24, in <module>
    from dm_control.suite import acrobot
  File "/Users/martin/miniforge3/lib/python3.9/site-packages/dm_control/suite/acrobot.py", line 20, in <module>
    from dm_control import mujoco
  File "/Users/martin/miniforge3/lib/python3.9/site-packages/dm_control/mujoco/__init__.py", line 18, in <module>
    from dm_control.mujoco.engine import action_spec
  File "/Users/martin/miniforge3/lib/python3.9/site-packages/dm_control/mujoco/engine.py", line 42, in <module>
    from dm_control.mujoco import index
  File "/Users/martin/miniforge3/lib/python3.9/site-packages/dm_control/mujoco/index.py", line 88, in <module>
    from dm_control.mujoco.wrapper import util
  File "/Users/martin/miniforge3/lib/python3.9/site-packages/dm_control/mujoco/wrapper/__init__.py", line 20, in <module>
    from dm_control.mujoco.wrapper.core import callback_context
  File "/Users/martin/miniforge3/lib/python3.9/site-packages/dm_control/mujoco/wrapper/core.py", line 65, in <module>
    raise Error("MuJoCo library version ({0}) does not match header version "
dm_control.mujoco.wrapper.core.Error: MuJoCo library version (210) does not match header version (211)
```