### PR TITLE
Use built-in types instead of numpy aliases

### DIFF
--- a/dm_control/composer/observation/obs_buffer_test.py
+++ b/dm_control/composer/observation/obs_buffer_test.py
@@ -31,7 +31,7 @@ def _generate_constant_schedule(update_timestep, delay,
 class BufferTest(parameterized.TestCase):
 
   def testOutOfOrderArrival(self):
-    buf = obs_buffer.Buffer(buffer_size=3, shape=(), dtype=np.float)
+    buf = obs_buffer.Buffer(buffer_size=3, shape=(), dtype=float)
     buf.insert(timestamp=0, delay=4, value=1)
     buf.insert(timestamp=1, delay=2, value=2)
     buf.insert(timestamp=2, delay=3, value=3)
@@ -43,15 +43,15 @@ class BufferTest(parameterized.TestCase):
 
   @parameterized.parameters(((3, 3),), ((),))
   def testStripSingletonDimension(self, shape):
-    buf = obs_buffer.Buffer(buffer_size=1, shape=shape, dtype=np.float,
+    buf = obs_buffer.Buffer(buffer_size=1, shape=shape, dtype=float,
                             strip_singleton_buffer_dim=True)
-    expected_value = np.full(shape, 42, dtype=np.float)
+    expected_value = np.full(shape, 42, dtype=float)
     buf.insert(timestamp=0, delay=0, value=expected_value)
     np.testing.assert_array_equal(buf.read(current_time=1), expected_value)
 
   def testPlanToSingleUndelayedObservation(self):
     buf = obs_buffer.Buffer(
-        buffer_size=1, shape=(), dtype=np.float)
+        buffer_size=1, shape=(), dtype=float)
     control_timestep = 20
     observation_schedule = _generate_constant_schedule(
         update_timestep=1, delay=0,
@@ -62,7 +62,7 @@ class BufferTest(parameterized.TestCase):
 
   def testPlanTwoStepsAhead(self):
     buf = obs_buffer.Buffer(
-        buffer_size=1, shape=(), dtype=np.float)
+        buffer_size=1, shape=(), dtype=float)
     control_timestep = 5
     observation_schedule = _generate_constant_schedule(
         update_timestep=2, delay=3,

--- a/dm_control/composer/observation/updater_test.py
+++ b/dm_control/composer/observation/updater_test.py
@@ -159,9 +159,9 @@ class UpdaterTest(parameterized.TestCase):
     observation_updater.reset(physics=physics, random_state=None)
 
     spec = observation_updater.observation_spec()
-    self.assertCorrectSpec(spec['repeated'], (5, 2), np.int, 'repeated')
-    self.assertCorrectSpec(spec['matrix'], (4, 2, 3), np.int, 'matrix')
-    self.assertCorrectSpec(spec['sqrt'], (3,), np.float, 'sqrt')
+    self.assertCorrectSpec(spec['repeated'], (5, 2), int, 'repeated')
+    self.assertCorrectSpec(spec['matrix'], (4, 2, 3), int, 'matrix')
+    self.assertCorrectSpec(spec['sqrt'], (3,), float, 'sqrt')
 
   @parameterized.parameters(True, False)
   def testObservation(self, pad_with_initial_value):

--- a/dm_control/entities/manipulators/base.py
+++ b/dm_control/entities/manipulators/base.py
@@ -59,7 +59,7 @@ class RobotArm(composer.Robot, metaclass=abc.ABCMeta):
     bound_joints = physics.bind(self.joints)
     limits = np.array(bound_joints.range, copy=True)
     is_hinge = bound_joints.type == mjbindings.enums.mjtJoint.mjJNT_HINGE
-    is_limited = bound_joints.limited.astype(np.bool)
+    is_limited = bound_joints.limited.astype(bool)
     invalid = ~is_hinge & ~is_limited  # All non-hinge joints must have limits.
     if any(invalid):
       invalid_str = '\n'.join(str(self.joints[i]) for i in np.where(invalid)[0])

--- a/dm_control/locomotion/arenas/covering.py
+++ b/dm_control/locomotion/arenas/covering.py
@@ -43,7 +43,7 @@ class _MazeWallCoveringContext:
     self._text_maze = text_maze
     self._wall_char = wall_char
     self._make_odd_sized_walls = make_odd_sized_walls
-    self._covered = np.full(text_maze.shape, False, dtype=np.bool)
+    self._covered = np.full(text_maze.shape, False, dtype=bool)
     self._maze_size = GridCoordinates(*text_maze.shape)
     self._next_start = GridCoordinates(0, 0)
     self._calculated = False

--- a/dm_control/locomotion/walkers/base.py
+++ b/dm_control/locomotion/walkers/base.py
@@ -141,7 +141,7 @@ class Walker(composer.Robot, metaclass=abc.ABCMeta):
       ])
     return specs.BoundedArray(
         shape=(len(self.actuators),),
-        dtype=np.float,
+        dtype=float,
         minimum=minimum,
         maximum=maximum,
         name='\t'.join([actuator.name for actuator in self.actuators]))

--- a/dm_control/locomotion/walkers/legacy_base.py
+++ b/dm_control/locomotion/walkers/legacy_base.py
@@ -241,7 +241,7 @@ class WalkerObservables(base.WalkerObservables):
         'sensordata',
         self._entity.mjcf_model.sensor.touch,
         corruptor=
-        lambda v, random_state: np.array(v > _TOUCH_THRESHOLD, dtype=np.float))
+        lambda v, random_state: np.array(v > _TOUCH_THRESHOLD, dtype=float))
 
   @composer.observable
   def sensors_rangefinder(self):

--- a/dm_control/mjcf/README.md
+++ b/dm_control/mjcf/README.md
@@ -144,7 +144,7 @@ order to avoid a clash with the Python `class` keyword:
 my_geom = mjcf_model.worldbody.body['foo'].body['bar'].geom['my_geom']
 print(isinstance(mjcf_model, mjcf.Element)) # True
 print(my_geom.name)    # 'my_geom'
-print(my_geom.pos)     # np.array([0., 1., 2.], dtype=np.float)
+print(my_geom.pos)     # np.array([0., 1., 2.], dtype=float)
 print(my_geom.class)   # SyntaxError
 print(my_geom.dclass)  # 'brick'
 ```
@@ -185,9 +185,9 @@ Attributes can be modified, added, or removed:
 
 ```python
 my_geom.pos = [1, 2, 3]
-print(my_geom.pos)   # np.array([1., 2., 3.], dtype=np.float)
+print(my_geom.pos)   # np.array([1., 2., 3.], dtype=float)
 my_geom.quat = [0, 1, 0, 0]
-print(my_geom.quat)  # np.array([0., 1., 0., 0.], dtype=np.float)
+print(my_geom.quat)  # np.array([0., 1., 0., 0.], dtype=float)
 del my_geom.quat
 print(my_geom.quat)   # None
 ```

--- a/dm_control/mjcf/attribute_test.py
+++ b/dm_control/mjcf/attribute_test.py
@@ -172,7 +172,7 @@ class AttributeTest(parameterized.TestCase):
     mujoco = self._mujoco
     mujoco.optional.float_array = [3, 2, 1]
     np.testing.assert_array_equal(mujoco.optional.float_array, [3, 2, 1])
-    self.assertEqual(mujoco.optional.float_array.dtype, np.float)
+    self.assertEqual(mujoco.optional.float_array.dtype, float)
     with self.assertRaisesRegex(ValueError, 'no more than 3 entries'):
       mujoco.optional.float_array = [0, 0, 0, -10]
     with self.assertRaisesRegex(ValueError, 'one-dimensional array'):
@@ -202,7 +202,7 @@ class AttributeTest(parameterized.TestCase):
     mujoco = self._mujoco
     mujoco.optional.int_array = [2, 2]
     np.testing.assert_array_equal(mujoco.optional.int_array, [2, 2])
-    self.assertEqual(mujoco.optional.int_array.dtype, np.int)
+    self.assertEqual(mujoco.optional.int_array.dtype, int)
     with self.assertRaisesRegex(ValueError, 'no more than 2 entries'):
       mujoco.optional.int_array = [0, 0, 10]
     # failed assignment should not change the value

--- a/dm_control/mjcf/skin.py
+++ b/dm_control/mjcf/skin.py
@@ -53,9 +53,9 @@ def parse(contents, body_getter):
     body_name = f.read(MAX_BODY_NAME_LENGTH).decode().split('\0')[0]
     body = lambda body_name=body_name: body_getter(body_name)
     bindpos = np.asarray(
-        struct.unpack('<fff', f.read(4*3)), dtype=np.float)
+        struct.unpack('<fff', f.read(4*3)), dtype=float)
     bindquat = np.asarray(
-        struct.unpack('<ffff', f.read(4*4)), dtype=np.float)
+        struct.unpack('<ffff', f.read(4*4)), dtype=float)
     vertex_count = struct.unpack('<i', f.read(4))[0]
     vertex_ids = np.frombuffer(f.read(4*vertex_count), dtype='<i4')
     vertex_weights = np.frombuffer(f.read(4*vertex_count), dtype='<f4')

--- a/dm_control/mujoco/engine.py
+++ b/dm_control/mujoco/engine.py
@@ -1021,11 +1021,11 @@ class TextOverlay:
 def action_spec(physics):
   """Returns a `BoundedArraySpec` matching the `physics` actuators."""
   num_actions = physics.model.nu
-  is_limited = physics.model.actuator_ctrllimited.ravel().astype(np.bool)
+  is_limited = physics.model.actuator_ctrllimited.ravel().astype(bool)
   control_range = physics.model.actuator_ctrlrange
-  minima = np.full(num_actions, fill_value=-constants.mjMAXVAL, dtype=np.float)
-  maxima = np.full(num_actions, fill_value=constants.mjMAXVAL, dtype=np.float)
+  minima = np.full(num_actions, fill_value=-constants.mjMAXVAL, dtype=float)
+  maxima = np.full(num_actions, fill_value=constants.mjMAXVAL, dtype=float)
   minima[is_limited], maxima[is_limited] = control_range[is_limited].T
 
   return specs.BoundedArray(
-      shape=(num_actions,), dtype=np.float, minimum=minima, maximum=maxima)
+      shape=(num_actions,), dtype=float, minimum=minima, maximum=maxima)

--- a/dm_control/mujoco/engine_test.py
+++ b/dm_control/mujoco/engine_test.py
@@ -532,7 +532,7 @@ class MujocoEngineTest(parameterized.TestCase):
     """
     physics = engine.Physics.from_xml_string(xml)
     spec = engine.action_spec(physics)
-    self.assertEqual(np.float, spec.dtype)
+    self.assertEqual(float, spec.dtype)
     np.testing.assert_array_equal(spec.minimum, [-constants.mjMAXVAL, -1.0])
     np.testing.assert_array_equal(spec.maximum, [constants.mjMAXVAL, 2.0])
 

--- a/dm_control/rl/control_test.py
+++ b/dm_control/rl/control_test.py
@@ -26,8 +26,8 @@ _CONSTANT_REWARD_VALUE = 1.0
 _CONSTANT_OBSERVATION = {'observations': np.asarray(_CONSTANT_REWARD_VALUE)}
 
 _ACTION_SPEC = specs.BoundedArray(
-    shape=(1,), dtype=np.float, minimum=0.0, maximum=1.0)
-_OBSERVATION_SPEC = {'observations': specs.Array(shape=(), dtype=np.float)}
+    shape=(1,), dtype=float, minimum=0.0, maximum=1.0)
+_OBSERVATION_SPEC = {'observations': specs.Array(shape=(), dtype=float)}
 
 
 class EnvironmentTest(parameterized.TestCase):
@@ -107,7 +107,7 @@ class EnvironmentTest(parameterized.TestCase):
 
   def test_flatten_observations(self):
     multimodal_obs = dict(_CONSTANT_OBSERVATION)
-    multimodal_obs['sensor'] = np.zeros(7, dtype=np.bool)
+    multimodal_obs['sensor'] = np.zeros(7, dtype=bool)
     self._task.get_observation = mock.Mock(return_value=multimodal_obs)
     env = control.Environment(
         physics=self._physics, task=self._task, flat_observation=True)

--- a/dm_control/suite/manipulator.py
+++ b/dm_control/suite/manipulator.py
@@ -196,7 +196,7 @@ class Bring(base.Task):
     while penetrating:
 
       # Randomise angles of arm joints.
-      is_limited = model.jnt_limited[_ARM_JOINTS].astype(np.bool)
+      is_limited = model.jnt_limited[_ARM_JOINTS].astype(bool)
       joint_range = model.jnt_range[_ARM_JOINTS]
       lower_limits = np.where(is_limited, joint_range[:, 0], -np.pi)
       upper_limits = np.where(is_limited, joint_range[:, 1], np.pi)

--- a/dm_control/suite/stacker.py
+++ b/dm_control/suite/stacker.py
@@ -149,7 +149,7 @@ class Stack(base.Task):
     while penetrating:
 
       # Randomise angles of arm joints.
-      is_limited = model.jnt_limited[_ARM_JOINTS].astype(np.bool)
+      is_limited = model.jnt_limited[_ARM_JOINTS].astype(bool)
       joint_range = model.jnt_range[_ARM_JOINTS]
       lower_limits = np.where(is_limited, joint_range[:, 0], -np.pi)
       upper_limits = np.where(is_limited, joint_range[:, 1], np.pi)

--- a/dm_control/suite/utils/parse_amc.py
+++ b/dm_control/suite/utils/parse_amc.py
@@ -123,7 +123,7 @@ def parse(file_name):
       while True:
         line = fid.readline().strip()
         if not line or line == str(frame_ind):
-          values.append(np.array(frame_vals, dtype=np.float))
+          values.append(np.array(frame_vals, dtype=float))
           break
         tokens = line.split()
         frame_vals.extend(tokens[1:])
@@ -134,7 +134,7 @@ def parse(file_name):
       while True:
         line = fid.readline().strip()
         if not line or line == str(frame_ind):
-          values.append(np.array(frame_vals, dtype=np.float))
+          values.append(np.array(frame_vals, dtype=float))
           break
         tokens = line.split()
         frame_vals.extend(tokens[1:])

--- a/dm_control/suite/wrappers/pixels_test.py
+++ b/dm_control/suite/wrappers/pixels_test.py
@@ -50,7 +50,7 @@ class FakeArrayObservationEnvironment(dm_env.Environment):
     pass
 
   def observation_spec(self):
-    return specs.Array(shape=(2,), dtype=np.float)
+    return specs.Array(shape=(2,), dtype=float)
 
 
 class PixelsTest(parameterized.TestCase):

--- a/dm_control/utils/inverse_kinematics_test.py
+++ b/dm_control/utils/inverse_kinematics_test.py
@@ -65,7 +65,7 @@ class _ResetArm:
 
   def _cache_bounds(self, physics):
     self._lower, self._upper = physics.named.model.jnt_range[_JOINTS].T
-    limited = physics.named.model.jnt_limited[_JOINTS].astype(np.bool)
+    limited = physics.named.model.jnt_limited[_JOINTS].astype(bool)
     # Positions for hinge joints without limits are sampled between 0 and 2pi
     self._lower[~limited] = 0
     self._upper[~limited] = 2 * np.pi

--- a/dm_control/utils/transformations_test.py
+++ b/dm_control/utils/transformations_test.py
@@ -68,7 +68,7 @@ class TransformationsTest(parameterized.TestCase):
     # Test for special values that often cause numerical issues.
     rng = [-np.pi, np.pi / 2, 0, np.pi / 2, np.pi]
     for euler_tup in itertools.product(rng, rng, rng):
-      euler_vec = np.array(euler_tup, dtype=np.float)
+      euler_vec = np.array(euler_tup, dtype=float)
       mat = transformations.euler_to_rmat(euler_vec, ordering='XYZ')
       quat = transformations.mat_to_quat(mat)
       tr_mat = transformations.quat_to_mat(quat)
@@ -91,7 +91,7 @@ class TransformationsTest(parameterized.TestCase):
     subsamps = 10
     rng = np.linspace(-np.pi, np.pi, subsamps)
     for euler_tup in itertools.product(rng, rng, rng):
-      euler_vec = np.array(euler_tup, dtype=np.float)
+      euler_vec = np.array(euler_tup, dtype=float)
       mat = transformations.euler_to_rmat(euler_vec, ordering='XYZ')
       mj_quat = np.empty(4, dtype=euler_vec.dtype)
       mjlib.mju_mat2Quat(mj_quat, mat.flatten())

--- a/dm_control/viewer/gui/glfw_gui.py
+++ b/dm_control/viewer/gui/glfw_gui.py
@@ -118,7 +118,7 @@ class GlfwMouse(base.InputEventsProcessor):
           self._glfw_setup, context.window)
 
     self._scale = framebuffer_width * 1.0 / window_width
-    self._last_mouse_pos = np.zeros(2, np.int)
+    self._last_mouse_pos = np.zeros(2, int)
 
     self._double_clicks = {}
 
@@ -143,7 +143,7 @@ class GlfwMouse(base.InputEventsProcessor):
       y: Vertical position of mouse, in pixels.
     """
     del window
-    position = np.array([x, y], np.int) * self._scale
+    position = np.array([x, y], int) * self._scale
     delta = position - self._last_mouse_pos
     self._last_mouse_pos = position
     self.add_event(self.on_move, position, delta)

--- a/dm_control/viewer/gui/glfw_gui_test.py
+++ b/dm_control/viewer/gui/glfw_gui_test.py
@@ -105,7 +105,7 @@ class GlfwMouseTest(absltest.TestCase):
       self.position = position
       self.translation = translation
     self.new_position = [100, 100]
-    self.handler._last_mouse_pos = np.array([99, 101], np.int)
+    self.handler._last_mouse_pos = np.array([99, 101], int)
     self.handler.on_move += move_handler
 
     self.handler._handle_move(self.window, self.new_position[0],


### PR DESCRIPTION
Numpy types like `np.{bool,int,float}` are just aliases of the built-in types. The built-in types should be preferred, as discussed e.g. in the [numpy 1.20.0 release notes](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).

This commit replaces all the numpy type alises with their corresponding built-in type.

This will keep the behavior unchanged, while silencing warnings like the following:
> [...]/lib/python3.9/site-packages/dm_control/mujoco/engine.py:1031: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  shape=(num_actions,), dtype=np.float, minimum=minima, maximum=maxima)
