### PR TITLE
Add missing walk task in Humanoid_CMU

### DIFF
--- a/dm_control/suite/humanoid_CMU.py
+++ b/dm_control/suite/humanoid_CMU.py
@@ -54,6 +54,15 @@ def stand(time_limit=_DEFAULT_TIME_LIMIT, random=None, environment_kwargs=None):
       physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP,
       **environment_kwargs)
 
+@SUITE.add()
+def walk(time_limit=_DEFAULT_TIME_LIMIT, random=None, environment_kwargs=None):
+  """Returns the Walk task."""
+  physics = Physics.from_xml_string(*get_model_and_assets())
+  task = HumanoidCMU(move_speed=_WALK_SPEED, random=random)
+  environment_kwargs = environment_kwargs or {}
+  return control.Environment(
+      physics, task, time_limit=time_limit, control_timestep=_CONTROL_TIMESTEP,
+      **environment_kwargs)
 
 @SUITE.add()
 def run(time_limit=_DEFAULT_TIME_LIMIT, random=None, environment_kwargs=None):


### PR DESCRIPTION
[Tassa et al., 2020, page 25, third paragraph from bottom](https://arxiv.org/abs/2006.12983) describes the Humanoid_CMU domain as having the `stand`, `walk` and `run` tasks -- however the `walk` task is missing.