### PR TITLE
Allow tendon `springlength` attribute to take two values.

### DIFF
--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -1485,7 +1485,7 @@
             <attribute name="width" type="float"/>
             <attribute name="material" type="reference"/>
             <attribute name="rgba" type="array" array_type="float" array_size="4"/>
-            <attribute name="springlength" type="float"/>
+            <attribute name="springlength" type="array" array_type="float" array_size="2"/>
             <attribute name="stiffness" type="float"/>
             <attribute name="damping" type="float"/>
             <attribute name="user" type="array" array_type="float"/>
@@ -1525,7 +1525,7 @@
             <attribute name="solimplimit" type="array" array_type="float" array_size="5"/>
             <attribute name="solreffriction" type="array" array_type="float" array_size="2"/>
             <attribute name="solimpfriction" type="array" array_type="float" array_size="5"/>
-            <attribute name="springlength" type="float"/>
+            <attribute name="springlength" type="array" array_type="float" array_size="2"/>
           </attributes>
           <children>
             <element name="joint" repeated="true">


### PR DESCRIPTION
Tendon `springlength` in mujoco can now take two values (see https://github.com/deepmind/mujoco/commit/893942a729123c193eb5aadaabca0a8042bd20d0). Update `dm_control` accordingly.