### PR TITLE
Fixes for problem with the brick envs passing an iterator to vstack of numpy

### DIFF
--- a/dm_control/manipulation/lift.py
+++ b/dm_control/manipulation/lift.py
@@ -67,9 +67,7 @@ class _VertexSitesMixin:
     """Add sites corresponding to the vertices of a box geom or site."""
     offsets = (
         (-half_length, half_length) for half_length in box_geom_or_site.size)
-
-    site_positions = list(itertools.product(*offsets))
-    site_positions = np.vstack(site_positions)
+    site_positions = np.vstack(list(itertools.product(*offsets)))
     if box_geom_or_site.pos is not None:
       site_positions += box_geom_or_site.pos
     self._vertices = []

--- a/dm_control/manipulation/lift.py
+++ b/dm_control/manipulation/lift.py
@@ -67,7 +67,9 @@ class _VertexSitesMixin:
     """Add sites corresponding to the vertices of a box geom or site."""
     offsets = (
         (-half_length, half_length) for half_length in box_geom_or_site.size)
-    site_positions = np.vstack(itertools.product(*offsets))
+
+    site_positions = list(itertools.product(*offsets))
+    site_positions = np.vstack(site_positions)
     if box_geom_or_site.pos is not None:
       site_positions += box_geom_or_site.pos
     self._vertices = []


### PR DESCRIPTION
This fixes the following warning being thrown by numpy:

```
.../venv/lib/python3.10/site-packages/dm_control/manipulation/lift.py:70: FutureWarning:
 arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
  site_positions = np.vstack(itertools.product(*offsets))
```