### PR TITLE
Fixed pip install git URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ at every single Git commit.
 
 If you want to install an unreleased version of `dm_control` directly from our
 repository, you can do so by running `pip install
-git+git://github.com/deepmind/dm_control.git`.
+git+https://github.com/deepmind/dm_control.git`.
 
 ## Rendering
 


### PR DESCRIPTION
Original URL with `git+git` fails as shown
```
> pip install git+git://github.com/deepmind/dm_control.git
Collecting git+git://github.com/deepmind/dm_control.git
  Cloning git://github.com/deepmind/dm_control.git to /tmp/pip-req-build-p9lzhp7w
  Running command git clone --filter=blob:none --quiet git://github.com/deepmind/dm_control.git /tmp/pip-req-build-p9lzhp7w
  fatal: unable to connect to github.com:
  github.com[0: 140.82.113.4]: errno=Connection timed out
```

Successfully installs with `git+https`
```
> pip install git+https://github.com/deepmind/dm_control.git
Collecting git+https://github.com/deepmind/dm_control.git
  Cloning https://github.com/deepmind/dm_control.git to /tmp/pip-req-build-3qzfvyvw
  Running command git clone --filter=blob:none --quiet https://github.com/deepmind/dm_control.git /tmp/pip-req-build-3qzfvyvw
  Resolved https://github.com/deepmind/dm_control.git to commit 5dec8898a4539589d4989f6553673e588e6a6b06
  Installing build dependencies ... done
  ...
```
