### PR TITLE
PyMJCF enable attachment without wrapping body

### DIFF
--- a/dm_control/mjcf/element.py
+++ b/dm_control/mjcf/element.py
@@ -1086,6 +1086,7 @@ class _AttachableElement(_ElementImpl):
       # if the child rotation is not defined, use base rotation as is
       if child_rot_type is None:
         self._maybe_set_attribute(child, base_rot_type, base_rot_value)
+        continue
 
       # convert base and child rotatiions to quaternions.
       base_rot_quat = self._apply_quat_convert(base_rot_type, base_rot_value, self.root)


### PR DESCRIPTION
- `attach` method now has an additional argument `exclude_wrapper_body`.
  - set to `False` for previous behavior
  - set to `True` for new behavior
- internal elements of attachment are positioned and rotated relative to the attachment site.
- aggregated rotation converters to quaternions for relative rotation
- implemented `xyaxes_to_quat` conversion method
- improved implementation of `euler_to_rmat` that handles all supported eulerseq values
- implemented generic function wrapper for `mju` rotation conversions that 

resolves #407