### PR TITLE
Correct `flexcomp` attribute types in schema.xml

### DIFF
--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -1102,10 +1102,10 @@
             <attribute name="name" type="identifier"/>
             <attribute name="type" type="keyword" valid_values="grid box cylinder ellipsoid mesh gmsh direct"/>
             <attribute name="count" type="array" array_type="int" array_size="3"/>
-            <attribute name="spacing" type="array" array_type="int" array_size="3"/>
+            <attribute name="spacing" type="array" array_type="float" array_size="3"/>
             <attribute name="scale" type="array" array_type="float" array_size="3"/>
             <attribute name="radius" type="float"/>
-            <attribute name="rigid" type="int"/>
+            <attribute name="rigid" type="string" valid_values="true false"/>
             <attribute name="mass" type="float"/>
             <attribute name="inertiabox" type="float"/>
             <attribute name="file" type="string"/>
@@ -1116,7 +1116,7 @@
             <attribute name="rgba" type="array" array_type="float" array_size="4"/>
             <attribute name="flatskin" type="int"/>
             <attribute name="pos" type="array" array_type="float" array_size="3"/>
-            <attribute name="quat" type="array" array_type="int" array_size="4"/>
+            <attribute name="quat" type="array" array_type="float" array_size="4"/>
             <attribute name="axisangle" type="array" array_type="float" array_size="4"/>
             <attribute name="xyaxis" type="array" array_type="float" array_size="6"/>
             <attribute name="zaxis" type="array" array_type="float" array_size="3"/>
@@ -1160,7 +1160,7 @@
                 <attribute name="solimp" type="array" array_type="float" array_size="5"/>
                 <attribute name="margin" type="float"/>
                 <attribute name="gap" type="float"/>
-                <attribute name="internal" type="int"/>
+                <attribute name="internal" type="string" valid_values="true false"/>
                 <attribute name="selfcollide" type="string" valid_values="none narrow bvh sap auto"/>
                 <attribute name="activelayers" type="int"/>
               </attributes>
@@ -1488,10 +1488,10 @@
                 <attribute name="name" type="identifier"/>
                 <attribute name="type" type="keyword" valid_values="grid box cylinder ellipsoid mesh gmsh direct"/>
                 <attribute name="count" type="array" array_type="int" array_size="3"/>
-                <attribute name="spacing" type="array" array_type="int" array_size="3"/>
+                <attribute name="spacing" type="array" array_type="float" array_size="3"/>
                 <attribute name="scale" type="array" array_type="float" array_size="3"/>
                 <attribute name="radius" type="float"/>
-                <attribute name="rigid" type="int"/>
+                <attribute name="rigid" type="string" valid_values="true false"/>
                 <attribute name="mass" type="float"/>
                 <attribute name="inertiabox" type="float"/>
                 <attribute name="file" type="string"/>
@@ -1502,11 +1502,12 @@
                 <attribute name="rgba" type="array" array_type="float" array_size="4"/>
                 <attribute name="flatskin" type="int"/>
                 <attribute name="pos" type="array" array_type="float" array_size="3"/>
-                <attribute name="quat" type="array" array_type="int" array_size="4"/>
+                <attribute name="quat" type="array" array_type="float" array_size="4"/>
                 <attribute name="axisangle" type="array" array_type="float" array_size="4"/>
                 <attribute name="xyaxis" type="array" array_type="float" array_size="6"/>
                 <attribute name="zaxis" type="array" array_type="float" array_size="3"/>
                 <attribute name="euler" type="array" array_type="float" array_size="3"/>
+                <attribute name="dim" type="int" required="true"/>
               </attributes>
               <children>
                 <element name="plugin" repeated="true" namespace="flexcomp">
@@ -1545,7 +1546,7 @@
                     <attribute name="solimp" type="array" array_type="float" array_size="5"/>
                     <attribute name="margin" type="float"/>
                     <attribute name="gap" type="float"/>
-                    <attribute name="internal" type="int"/>
+                    <attribute name="internal" type="string" valid_values="true false"/>
                     <attribute name="selfcollide" type="string" valid_values="none narrow bvh sap auto"/>
                     <attribute name="activelayers" type="int"/>
                   </attributes>


### PR DESCRIPTION
Align the attribute types with the [official documentation](4c3c5f8decb7c03fc97c39a84034080cd756816f). Fixes the following errors:

- `spacing`'s wrong conversion to int could lead to `XML Error: Spacing must be larger than geometry size` (e.g. 0.2 -> 0)
- Setting and `edge`'s internal collisions to `false` leads to `ValueError: Expect an integer value: got false` (same for `rigid` attribute)