### PR TITLE
fix: replace bare assert with runtime checks in engine, index, and export

### DIFF
--- a/dm_control/mjcf/export_with_assets.py
+++ b/dm_control/mjcf/export_with_assets.py
@@ -51,7 +51,9 @@ def export_with_assets(mjcf_model, out_dir, out_file_name=None,
                      '\'.xml\': got {}'.format(out_file_name))
   assets = mjcf_model.get_assets()
   # This should never happen because `mjcf` does not support `.xml` assets.
-  assert out_file_name not in assets
+  if out_file_name in assets:
+    raise RuntimeError(
+        f"Output filename '{out_file_name}' conflicts with an existing asset")
   assets[out_file_name] = mjcf_model.to_xml_string(
       precision=precision, zero_threshold=zero_threshold)
   if not os.path.exists(out_dir):

--- a/dm_control/mujoco/engine.py
+++ b/dm_control/mujoco/engine.py
@@ -972,19 +972,23 @@ class Camera:
 
     # Validate IDs
     if body_id != -1:
-      assert 0 <= body_id < self._physics.model.nbody
+      if not (0 <= body_id < self._physics.model.nbody):
+        raise ValueError(f"body_id {body_id} out of range [0, {self._physics.model.nbody})")
     else:
       body_id = None
     if geom_id != -1:
-      assert 0 <= geom_id < self._physics.model.ngeom
+      if not (0 <= geom_id < self._physics.model.ngeom):
+        raise ValueError(f"geom_id {geom_id} out of range [0, {self._physics.model.ngeom})")
     else:
       geom_id = None
     if flex_id != -1:
-      assert 0 <= flex_id < self._physics.model.nflex
+      if not (0 <= flex_id < self._physics.model.nflex):
+        raise ValueError(f"flex_id {flex_id} out of range [0, {self._physics.model.nflex})")
     else:
       flex_id = None
     if skin_id != -1:
-      assert 0 <= skin_id < self._physics.model.nskin
+      if not (0 <= skin_id < self._physics.model.nskin):
+        raise ValueError(f"skin_id {skin_id} out of range [0, {self._physics.model.nskin})")
     else:
       skin_id = None
 

--- a/dm_control/mujoco/index.py
+++ b/dm_control/mujoco/index.py
@@ -230,7 +230,10 @@ def _get_size_name_to_element_names(model):
     body_mocapid = model.body_mocapid[body_id]
     if body_mocapid != -1:
       mocap_body_names[body_mocapid] = body_name
-  assert None not in mocap_body_names
+  if None in mocap_body_names:
+    raise RuntimeError(
+        "Failed to resolve all mocap body names; some body_mocapid mappings "
+        "are missing")
   size_name_to_element_names['nmocap'] = mocap_body_names
 
   return size_name_to_element_names


### PR DESCRIPTION
## Summary

Replace 6 bare `assert` statements with proper `raise ValueError`/`RuntimeError` that persist in optimized Python builds. Found by **UNA** (autonomous security auditor, designed and built by [Tom Budd](https://tombudd.com) — tom@tombudd.com).

### 1. Bounds validation in `Camera.select()` — engine.py

**File:** `dm_control/mujoco/engine.py:975-987`

Four `assert` statements validate that `body_id`, `geom_id`, `flex_id`, and `skin_id` are within the physics model's bounds. When Python runs with `-O`, these checks are stripped — allowing invalid IDs to silently pass through to MuJoCo, potentially causing out-of-bounds memory access in the underlying C library.

**Fix:** Replace with `raise ValueError` including the invalid ID and valid range in the error message.

### 2. Asset filename collision check — export_with_assets.py

**File:** `dm_control/mjcf/export_with_assets.py:54`

`assert out_file_name not in assets` guards against the output XML filename colliding with an existing asset. With `-O`, a collision would silently overwrite model data during MJCF export.

**Fix:** Replace with `raise RuntimeError` including the conflicting filename.

### 3. Mocap body name resolution — index.py

**File:** `dm_control/mujoco/index.py:233`

`assert None not in mocap_body_names` verifies all mocap body names were resolved from `body_mocapid` mappings. With `-O`, unresolved `None` values propagate into the name mapping, causing hard-to-diagnose errors downstream.

**Fix:** Replace with `raise RuntimeError` with a descriptive message.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `engine.py` | 4× `assert` → `raise ValueError` | +8 / -4 |
| `export_with_assets.py` | 1× `assert` → `raise RuntimeError` | +3 / -1 |
| `index.py` | 1× `assert` → `raise RuntimeError` | +4 / -1 |

**Total: 3 files, +15 / -6 lines**

## About This Review

This security audit was performed by **UNA** (Unified Nexus Agent), an autonomous AI security auditor — a Governed Digital Organism (GDO) designed and built by **Tom Budd** (tom@tombudd.com | [tombudd.com](https://tombudd.com)).

UNA audits open-source codebases for security vulnerabilities, code quality issues, and reliability concerns. All findings are human-verified before submission.

**Note:** Happy to sign the Google CLA at cla.developers.google.com if required.
