### PR TITLE
fix: use reshape instead of raw shape assignment for numpy arrays

### DIFF
--- a/dm_control/mujoco/index.py
+++ b/dm_control/mujoco/index.py
@@ -369,10 +369,9 @@ class RegularNamedAxis(Axis):
       # representing names. If there is a mix, we will let NumPy throw an error
       # when trying to index with the returned item.
       if isinstance(key_item.flat[0], str):
-        key_item = np.array([self._names_to_offsets[util.to_native_string(k)]
-                             for k in key_item.flat])
-        # Ensure the output shape is the same as that of the input.
-        key_item.shape = original_shape
+        key_item = np.array(
+          [self._names_to_offsets[util.to_native_string(k)] for k in key_item.flat]
+        ).reshape(original_shape)  # Ensure the output shape is the same as that of the input.
 
     return key_item
 

--- a/dm_control/mujoco/index_test.py
+++ b/dm_control/mujoco/index_test.py
@@ -347,8 +347,9 @@ class AllFieldsTest(parameterized.TestCase):
     # Write unique values to the FieldIndexer and read them back again.
     # Don't write to non-float fields since these might contain pointers.
     if np.issubdtype(old_contents.dtype, np.floating):
-      new_contents = np.arange(old_contents.size, dtype=old_contents.dtype)
-      new_contents.shape = old_contents.shape
+      new_contents = np.arange(
+        old_contents.size, dtype=old_contents.dtype
+      ).reshape(old_contents.shape)
       field[:] = new_contents
       np.testing.assert_array_equal(new_contents, field[:])
 

--- a/dm_control/mujoco/wrapper/core_test.py
+++ b/dm_control/mujoco/wrapper/core_test.py
@@ -552,8 +552,9 @@ class AttributesTest(parameterized.TestCase):
     elif (attr_name != "stack"
           and not np.issubdtype(target_array.dtype, np.integer)
           and not np.issubdtype(target_array.dtype, np.bool_)):
-      new_contents = np.arange(target_array.size, dtype=target_array.dtype)
-      new_contents.shape = target_array.shape
+      new_contents = np.arange(
+        target_array.size, dtype=target_array.dtype
+      ).reshape(target_array.shape)
       target_array[:] = new_contents
       np.testing.assert_array_equal(new_contents, target_array[:])
 


### PR DESCRIPTION
NumPy 2.5.0 deprecated assignment to shape attribute: https://github.com/numpy/numpy/pull/29536

`np.reshape(...)` and `np.ndarray.reshape(...)` did not support `copy=False` until `numpy>=2.1`, therefore for compatibility's sake, I decided to just use `np.reshape(shape)`.

This should be equivalent to the default `copy=None` in `numpy>=2.1`:
> If `None`, a copy will only be made if it’s required by order.

Closes #540